### PR TITLE
ci: do not depend on system installed gitchangelog

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
   hooks:
   - id: gitchangelog
     language: python
-    additional_dependencies: ["gitchangelog"]
+    additional_dependencies: ["gitchangelog", "pystache"]
     always_run: true
     pass_filenames: false
     name: Generate changelog

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,8 @@ repos:
 - repo: local
   hooks:
   - id: gitchangelog
-    language: system
+    language: python
+    additional_dependencies: ["gitchangelog"]
     always_run: true
     pass_filenames: false
     name: Generate changelog


### PR DESCRIPTION
By using `language: python` and `additional_dependencies: ...` it will be installed in the pre-commit created virtualenv.