### PR TITLE
fix: replace pkg_resources with stdlib

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,6 @@ repos:
   - id: mypy
     name: Run type checks
     args: ["--ignore-missing-imports"]
-    additional_dependencies: ["types-setuptools"]
 - repo: local
   hooks:
   - id: gitchangelog

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ sysaidmin = "sysaidmin.cli:cli"
 [tool.poetry.dependencies]
 python = ">=3.8.1"
 openai = "^1.3.5"
-setuptools = "^69.5.1"
 
 [tool.poetry.dev-dependencies]
 

--- a/sysaidmin/cli.py
+++ b/sysaidmin/cli.py
@@ -6,14 +6,14 @@ import subprocess
 import sys
 import tempfile
 import time
+from importlib import metadata
 from typing import Optional
 from typing import Tuple
 
 import openai
-import pkg_resources
 
 try:
-    VERSION = pkg_resources.get_distribution("sysaidmin").version
+    VERSION = metadata.version("sysaidmin")
 except Exception:
     VERSION = "0.0.0"
 


### PR DESCRIPTION
No need to depend on setuptools just to get the version, we can use [`importlib.metadata`](https://docs.python.org/3/library/importlib.metadata.html#overview)
